### PR TITLE
Add straight line drawing.

### DIFF
--- a/src/papaya_core.h
+++ b/src/papaya_core.h
@@ -162,6 +162,8 @@ struct BrushInfo
     bool RtDragWithShift;
     int32 RtDragStartDiameter;
     float RtDragStartHardness, RtDragStartOpacity;
+    bool DrawLineSegment;
+    Vec2 LineSegmentStartUV;
     bool BeingDragged;
 };
 

--- a/src/papaya_core.h
+++ b/src/papaya_core.h
@@ -165,6 +165,11 @@ struct BrushInfo
     bool DrawLineSegment;
     Vec2 LineSegmentStartUV;
     bool BeingDragged;
+    bool IsStraightDrag;
+    bool WasStraightDrag;
+    bool StraightDragSnapX;
+    bool StraightDragSnapY;
+    Vec2 StraightDragStartUV;
 };
 
 struct EyeDropperInfo


### PR DESCRIPTION
Add shift+clicking for drawing arbitrary straight line segments and shift+dragging during a brush stroke for horizontal and vertical lines.

Note that for shift+dragging I modify Mouse.UV and Mouse.Pos and call Platform::SetMousePosition, so that the cursor does not move away from the line.

Implements #10 except for the undo integration for arbitrary straight lines.
