### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/ui/windows_ui.cpp
+++ b/src/ui/windows_ui.cpp
@@ -106,7 +106,7 @@ char* platform::save_file_dialog()
         }
     }
 
-    char buffer[256];
+    char buffer[MAX_PATH+2];
     sprintf(buffer, "%s\n", file_name);
     OutputDebugStringA(buffer);
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

As you can see, save dialog returns filename with maximal length equals to MAX_PATH (260).
But when you make sprintf it with \n into the buffer, which has 256 length, this may lead to buffer overflow. For example, if you select filename from dialog, which path is 256, 257, 258... characters long.
In this case, the program will crashes.
I set buffer size to MAX_PATH+2 for maximal path and \n and \0 at the end of the line.

[V512](https://www.viva64.com/en/w/v512/) A call of the 'sprintf' function will lead to overflow of the buffer 'buffer'. windows_ui.cpp 110
